### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
  A MCP (Model Context Protocol) provider Deepseek reasoning content to MCP-enabled AI Clients, like Claude Desktop. Supports access to Deepseek's thought processes from the Deepseek API service or from a local Ollama server.
 
+<a href="https://glama.ai/mcp/servers/d7spzsfuwz"><img width="380" height="200" src="https://glama.ai/mcp/servers/d7spzsfuwz/badge" alt="Deepseek Thinker Server MCP server" /></a>
+
 ## Core Features
 
 - 🤖 **Dual Mode Support**


### PR DESCRIPTION
This PR adds a badge for the [Deepseek Thinker MCP Server](https://glama.ai/mcp/servers/d7spzsfuwz) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/d7spzsfuwz"><img width="380" height="200" src="https://glama.ai/mcp/servers/d7spzsfuwz/badge" alt="Deepseek Thinker Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.